### PR TITLE
[PT-1271] Add nullable field option to simple, select and httpselect

### DIFF
--- a/examples/Fields.elm
+++ b/examples/Fields.elm
@@ -13,25 +13,27 @@ fields =
     [ \order ->
         ( "Uneditable field"
         , FormField.text
-            { required = True
+            { required = False
             , label = "Uneditable Field"
             , width = Width.FullSize
             , enabledBy = Nothing
             , order = order
             , value = ""
             , disabled = True
+            , nullable = False
             }
         )
     , \order ->
         ( "not a valid email field"
         , FormField.email
-            { required = True
+            { required = False
             , label = "Not relevant Email Address"
             , width = Width.FullSize
             , enabledBy = Nothing
             , order = order
             , value = ""
             , disabled = True
+            , nullable = False
             }
         )
     , \order ->
@@ -44,6 +46,7 @@ fields =
             , order = order
             , value = ""
             , disabled = False
+            , nullable = True
             }
         )
     , \order ->
@@ -56,6 +59,7 @@ fields =
             , order = order
             , value = ""
             , disabled = False
+            , nullable = False
             }
         )
     , \order ->
@@ -68,12 +72,13 @@ fields =
             , order = order
             , value = ""
             , disabled = False
+            , nullable = False
             }
         )
     , \order ->
         ( "age"
         , FormField.age
-            { required = True
+            { required = False
             , label = "Age"
             , width = Width.FullSize
             , enabledBy = Nothing
@@ -85,19 +90,20 @@ fields =
     , \order ->
         ( "dateOfBirth"
         , FormField.dateOfBirth
-            { required = True
+            { required = False
             , label = "Date of Birth"
             , width = Width.FullSize
             , enabledBy = Nothing
             , order = order
             , value = ""
             , disabled = False
+            , nullable = True
             }
         )
     , \order ->
         ( "something"
         , FormField.select
-            { required = True
+            { required = False
             , label = "Something"
             , width = Width.FullSize
             , enabledBy = Nothing
@@ -109,12 +115,13 @@ fields =
                 , { label = Nothing, value = "Two" }
                 ]
             , disabled = True
+            , nullable = False
             }
         )
     , \order ->
         ( "state"
         , FormField.select
-            { required = True
+            { required = False
             , label = "State"
             , width = Width.FullSize
             , enabledBy = Nothing
@@ -132,12 +139,13 @@ fields =
                 , { label = Nothing, value = "Western Australia" }
                 ]
             , disabled = False
+            , nullable = True
             }
         )
     , \order ->
         ( "modes"
         , FormField.multiSelect
-            { required = True
+            { required = False
             , label = "What modes of transport do you use?"
             , placeholder = "Mode"
             , width = Width.FullSize
@@ -158,7 +166,7 @@ fields =
     , \order ->
         ( "updates"
         , FormField.radio
-            { required = True
+            { required = False
             , label = "Are you up to date with your updates?"
             , width = Width.FullSize
             , enabledBy = Nothing

--- a/examples/Update.elm
+++ b/examples/Update.elm
@@ -1,8 +1,10 @@
 module Update exposing (..)
 
 import Dialog
+import Form.Fields as Fields
 import Form.Update as FormUpdate
 import Form.Validate as Validate
+import Json.Encode as Encode
 import Model
 import Msg
 
@@ -23,7 +25,7 @@ update msg model =
                 newDialog =
                     Dialog.info
                         { title = "Info"
-                        , message = "Create success"
+                        , message = "Success. Encoded form: " ++ (Encode.encode 1 <| Encode.dict identity identity (Fields.encode model.form))
                         }
             in
             model.form

--- a/src/Form/Field/Json.elm
+++ b/src/Form/Field/Json.elm
@@ -43,6 +43,7 @@ type alias JsonSimpleFieldProperties =
     , enabledBy : Maybe String
     , tipe : FieldType.SimpleFieldType
     , disabled : Maybe Bool
+    , nullable : Maybe Bool
     }
 
 
@@ -55,6 +56,7 @@ type alias JsonSelectFieldProperties =
     , default : Maybe String
     , options : List Option.Option
     , disabled : Maybe Bool
+    , nullable : Maybe Bool
     }
 
 
@@ -67,6 +69,7 @@ type alias JsonHttpSelectFieldProperties =
     , default : Maybe String
     , url : String
     , disabled : Maybe Bool
+    , nullable : Maybe Bool
     }
 
 
@@ -197,7 +200,7 @@ decoderForType fieldType =
 toField : Time.Posix -> Int -> JsonField -> ( String, Field.Field )
 toField time order field =
     case field of
-        JsonSimpleField { tipe, required, key, label, width, enabledBy, disabled } ->
+        JsonSimpleField { tipe, required, key, label, width, enabledBy, disabled, nullable } ->
             ( key
             , Field.StringField_ <|
                 Field.SimpleField
@@ -209,6 +212,7 @@ toField time order field =
                     , order = order
                     , value = FieldType.defaultValue time tipe |> Maybe.withDefault ""
                     , disabled = Maybe.withDefault False disabled
+                    , nullable = Maybe.withDefault False nullable
                     }
             )
 
@@ -227,7 +231,7 @@ toField time order field =
                     }
             )
 
-        JsonSelectField { required, key, label, width, default, enabledBy, options, disabled } ->
+        JsonSelectField { required, key, label, width, default, enabledBy, options, disabled, nullable } ->
             ( key
             , Field.StringField_ <|
                 Field.SelectField
@@ -240,10 +244,11 @@ toField time order field =
                     , options = options
                     , value = Maybe.withDefault "" default
                     , disabled = Maybe.withDefault False disabled
+                    , nullable = Maybe.withDefault False nullable
                     }
             )
 
-        JsonHttpSelectField { required, key, label, width, default, enabledBy, url, disabled } ->
+        JsonHttpSelectField { required, key, label, width, default, enabledBy, url, disabled, nullable } ->
             ( key
             , Field.StringField_ <|
                 Field.HttpSelectField
@@ -257,6 +262,7 @@ toField time order field =
                     , options = RemoteData.NotAsked
                     , value = Maybe.withDefault "" default
                     , disabled = Maybe.withDefault False disabled
+                    , nullable = Maybe.withDefault False nullable
                     }
             )
 
@@ -367,6 +373,7 @@ decoderSimpleJson tipe =
         |> DecodePipeline.optional "enabledBy" (Decode.map Just Decode.string) Nothing
         |> DecodePipeline.hardcoded tipe
         |> DecodePipeline.optional "disabled" (Decode.map Just Decode.bool) Nothing
+        |> DecodePipeline.optional "nullable" (Decode.map Just Decode.bool) Nothing
 
 
 decoderCheckboxJson : FieldType.CheckboxFieldType -> Decode.Decoder JsonCheckboxFieldProperties
@@ -392,6 +399,7 @@ decoderSelectJson =
         |> DecodePipeline.optional "default" (Decode.maybe Decode.string) Nothing
         |> DecodePipeline.required "options" (Decode.list Option.decoder)
         |> DecodePipeline.optional "disabled" (Decode.map Just Decode.bool) Nothing
+        |> DecodePipeline.optional "nullable" (Decode.map Just Decode.bool) Nothing
 
 
 decoderHttpSelectJson : Decode.Decoder JsonHttpSelectFieldProperties
@@ -405,6 +413,7 @@ decoderHttpSelectJson =
         |> DecodePipeline.optional "default" (Decode.maybe Decode.string) Nothing
         |> DecodePipeline.required "url" Decode.string
         |> DecodePipeline.optional "disabled" (Decode.map Just Decode.bool) Nothing
+        |> DecodePipeline.optional "nullable" (Decode.map Just Decode.bool) Nothing
 
 
 decoderMultiSelectJson : Decode.Decoder JsonMultiSelectFieldProperties

--- a/src/Form/Validate/StringField.elm
+++ b/src/Form/Validate/StringField.elm
@@ -118,7 +118,10 @@ validate locale field =
             String.trim (Field.getStringValue_ field)
     in
     if String.isEmpty trimmed then
-        if Field.isRequired (Field.StringField_ field) then
+        if Field.isNullable field then
+            Ok trimmed
+
+        else if Field.isRequired (Field.StringField_ field) then
             Err EmptyError
 
         else

--- a/src/Form/View/Select.elm
+++ b/src/Form/View/Select.elm
@@ -64,6 +64,7 @@ httpSelect key properties =
                 , enabledBy = properties.enabledBy
                 , order = properties.order
                 , disabled = properties.disabled
+                , nullable = False
                 }
         )
         properties.options

--- a/tests/Form/Field/JsonSpec.elm
+++ b/tests/Form/Field/JsonSpec.elm
@@ -40,7 +40,8 @@ suite =
                                 "key": "name",
                                 "label": "Full Name",
                                 "type": "text",
-                                "width": "50%"
+                                "width": "50%",
+                                "nullable": true
                             }"""
                     in
                     Decode.decodeString decoder json
@@ -57,6 +58,7 @@ suite =
                                         , order = order
                                         , value = ""
                                         , disabled = False
+                                        , nullable = True
                                         }
                                 )
                             )
@@ -126,6 +128,7 @@ suite =
                             "type": "select",
                             "width": "50%",
                             "default": "Dog",
+                            "nullable": true,
                             "options": [
                                 { "value": "Dog" },
                                 { "value": "Cat" },
@@ -158,6 +161,7 @@ suite =
                                         , value = "Dog"
                                         , order = order
                                         , disabled = False
+                                        , nullable = True
                                         }
                                     )
                                 )
@@ -209,7 +213,8 @@ suite =
                             "label": "Tag",
                             "type": "httpSelect",
                             "width": "50%",
-                            "url": "tags"
+                            "url": "tags",
+                            "nullable": true
                         }"""
                     in
                     Decode.decodeString decoder json
@@ -228,6 +233,7 @@ suite =
                                         , value = ""
                                         , order = order
                                         , disabled = False
+                                        , nullable = True
                                         }
                                     )
                                 )
@@ -365,6 +371,7 @@ suite =
                                             , order = order
                                             , value = "Foo Bar"
                                             , disabled = False
+                                            , nullable = False
                                             }
                                   )
                                 ]
@@ -388,6 +395,7 @@ suite =
                                             , order = order
                                             , value = "bar"
                                             , disabled = False
+                                            , nullable = False
                                             }
                                   )
                                 ]
@@ -422,6 +430,7 @@ suite =
                                                   }
                                                 ]
                                             , disabled = False
+                                            , nullable = False
                                             }
                                   )
                                 ]
@@ -447,6 +456,7 @@ suite =
                                             , options = RemoteData.NotAsked
                                             , url = "tags"
                                             , disabled = False
+                                            , nullable = False
                                             }
                                   )
                                 ]
@@ -470,6 +480,7 @@ suite =
                                             , order = 1
                                             , value = "2022-01-01"
                                             , disabled = False
+                                            , nullable = False
                                             }
                                   )
                                 , ( "metadata.email"
@@ -483,6 +494,7 @@ suite =
                                             , order = order
                                             , value = "foo@example.com"
                                             , disabled = False
+                                            , nullable = False
                                             }
                                   )
                                 , ( "metadata.name"
@@ -496,6 +508,7 @@ suite =
                                             , order = 2
                                             , value = "Foo Bar"
                                             , disabled = False
+                                            , nullable = False
                                             }
                                   )
                                 ]

--- a/tests/Form/FieldSpec.elm
+++ b/tests/Form/FieldSpec.elm
@@ -15,7 +15,7 @@ suite =
             \initialString updateString ->
                 let
                     fieldValues =
-                        { required = False, label = "", width = Width.HalfSize, enabledBy = Nothing, order = 0, value = initialString, disabled = False }
+                        { required = False, label = "", width = Width.HalfSize, enabledBy = Nothing, order = 0, value = initialString, disabled = False, nullable = False }
 
                     field =
                         Field.text fieldValues

--- a/tests/Form/Validate/StringFieldSpec.elm
+++ b/tests/Form/Validate/StringFieldSpec.elm
@@ -129,4 +129,5 @@ simpleField tipe { required, value } =
         , value = value
         , tipe = tipe
         , disabled = False
+        , nullable = False
         }


### PR DESCRIPTION
This adds the ability to have nullable fields.

For example, you might have an optional `email` field that can be empty - rather than submitting "" or `undefined`, this nullable option will submit any fields with "" (string fields) as `"blah": null`.

The example form has been changed to also show the encoded form in the dialog popup:

<img width="680" alt="image" src="https://user-images.githubusercontent.com/11861995/173524300-60ba74b2-0fe8-44df-bc59-754e68d483d7.png">
